### PR TITLE
Two small issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the official implementation of Instant3dit. We provide the weights and i
 
 ## Multiview Edited Image Generation
 The code has been tested on python 3.8 and 3.10 with pytorch 2.1.2 and 2.7.0, both with cuda 11.8, but should work for all versions in between.
-1. run `pip install requirements.txt` to install dependencies
+1. run `pip install -r requirements.txt` to install dependencies
 2. download the multiview inpainting [SDXL weights](https://drive.google.com/drive/folders/1yLdhgEqv0FBD19r4RPBsBzpa3congkDv?usp=sharing)
 3. replace Path/to/Instant3dit_model in the default argument with the path to the SDXL multiview inpainting checkpoint folder downloaded in the previous step.
 

--- a/inference.py
+++ b/inference.py
@@ -188,6 +188,9 @@ output.save(Path(output_path, '{}.png'.format(prompt[0].replace(' ', '_'))))
 # output to LRM
 print ('output_type : {}'.format(args.output_type), flush=True)
 
+# Free VRAM used by the diffusion pipeline
+del pipe
+
 if args.output_type in ['mesh']:
     from LRMs.mesh import reconstruct_using_mesh_lrm
     c2w, intrinsics = get_zero123plus_input_cameras(azimuth_offset = args.azimuth_offset)


### PR DESCRIPTION
1. vram limitations.
add "del pipe" code in interface.py to support gpus with lower amounts of vram.
the pipe variable isn't needed in the following mesh reconstruction code.
as mentioned in this comment: https://github.com/amirbarda/Instant3dit/issues/1#issuecomment-2883148324

2. readme small error.
the "pip install requirements.txt" command doesn't work, replaced with "pip install -r requirements.txt" instead